### PR TITLE
Add dynamic email subject support

### DIFF
--- a/docs/docs/reference/core-plugins/email-plugin/email-event-handler.md
+++ b/docs/docs/reference/core-plugins/email-plugin/email-event-handler.md
@@ -133,7 +133,7 @@ class EmailEventHandler<T extends string = string, Event extends EventWithContex
     setRecipient(setRecipientFn: (event: Event) => string) => EmailEventHandler<T, Event>;
     setLanguageCode(setLanguageCodeFn: (event: Event) => LanguageCode | undefined) => EmailEventHandler<T, Event>;
     setTemplateVars(templateVarsFn: SetTemplateVarsFn<Event>) => EmailEventHandler<T, Event>;
-    setSubject(defaultSubject: string) => EmailEventHandler<T, Event>;
+    setSubject(subject: string | SetSubjectFn<Event>) => EmailEventHandler<T, Event>;
     setFrom(from: string) => EmailEventHandler<T, Event>;
     setOptionalAddressFields(optionalAddressFieldsFn: SetOptionalAddressFieldsFn<Event>) => ;
     setAttachments(setAttachmentsFn: SetAttachmentsFn<Event>) => ;
@@ -178,10 +178,12 @@ A function which returns an object hash of variables which will be made availabl
 and subject line for interpolation.
 ### setSubject
 
-<MemberInfo kind="method" type={`(defaultSubject: string) => <a href='/reference/core-plugins/email-plugin/email-event-handler#emaileventhandler'>EmailEventHandler</a>&#60;T, Event&#62;`}   />
+<MemberInfo kind="method" type={`(subject: string | <a href='/reference/core-plugins/email-plugin/email-plugin-types#setsubjectfn'>SetSubjectFn</a>&#60;Event&#62;) => <a href='/reference/core-plugins/email-plugin/email-event-handler#emaileventhandler'>EmailEventHandler</a>&#60;T, Event&#62;`}   />
 
-Sets the default subject of the email. The subject string may use Handlebars variables defined by the
-setTemplateVars() method.
+Sets the default subject of the email. The subject can be specified as either a static string or a
+function which will be called with the event, context and injector. When a function is used, the
+returned string will be used as the subject. Handlebars variables defined by the
+setTemplateVars() method may be used in the subject string.
 ### setFrom
 
 <MemberInfo kind="method" type={`(from: string) => <a href='/reference/core-plugins/email-plugin/email-event-handler#emaileventhandler'>EmailEventHandler</a>&#60;T, Event&#62;`}   />

--- a/docs/docs/reference/core-plugins/email-plugin/email-plugin-types.md
+++ b/docs/docs/reference/core-plugins/email-plugin/email-plugin-types.md
@@ -143,6 +143,21 @@ type SetTemplateVarsFn<Event> = (
 ```
 
 
+## SetSubjectFn
+
+<GenerationInfo sourceFile="packages/email-plugin/src/types.ts" sourceLine="386" packageName="@vendure/email-plugin" />
+
+A function used to dynamically generate the subject line of an email.
+See <a href='/reference/core-plugins/email-plugin/email-event-handler#emaileventhandler'>EmailEventHandler</a>.setSubject().
+
+```ts title="Signature"
+type SetSubjectFn<Event> = (
+    event: Event,
+    ctx: RequestContext,
+    injector: Injector,
+) => string | Promise<string>
+```
+
 ## SetAttachmentsFn
 
 <GenerationInfo sourceFile="packages/email-plugin/src/types.ts" sourceLine="388" packageName="@vendure/email-plugin" />

--- a/packages/email-plugin/src/handler/event-handler.ts
+++ b/packages/email-plugin/src/handler/event-handler.ts
@@ -15,6 +15,7 @@ import {
     SetAttachmentsFn,
     SetOptionalAddressFieldsFn,
     SetTemplateVarsFn,
+    SetSubjectFn,
 } from '../types';
 
 /**
@@ -140,7 +141,7 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
     private setOptionalAddressFieldsFn?: SetOptionalAddressFieldsFn<Event>;
     private filterFns: Array<(event: Event) => boolean> = [];
     private configurations: EmailTemplateConfig[] = [];
-    private defaultSubject: string;
+    private subject: string | SetSubjectFn<Event>;
     private from: string;
     private optionalAddressFields: {
         cc?: string;
@@ -214,8 +215,8 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
      * Sets the default subject of the email. The subject string may use Handlebars variables defined by the
      * setTemplateVars() method.
      */
-    setSubject(defaultSubject: string): EmailEventHandler<T, Event> {
-        this.defaultSubject = defaultSubject;
+    setSubject(subject: string | SetSubjectFn<Event>): EmailEventHandler<T, Event> {
+        this.subject = subject;
         return this;
     }
 
@@ -318,7 +319,7 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
         asyncHandler.setOptionalAddressFieldsFn = this.setOptionalAddressFieldsFn;
         asyncHandler.filterFns = this.filterFns;
         asyncHandler.configurations = this.configurations;
-        asyncHandler.defaultSubject = this.defaultSubject;
+        asyncHandler.subject = this.subject;
         asyncHandler.from = this.from;
         asyncHandler._mockEvent = this._mockEvent as any;
         return asyncHandler;
@@ -370,7 +371,14 @@ export class EmailEventHandler<T extends string = string, Event extends EventWit
         const { ctx } = event;
         const languageCode = this.setLanguageCodeFn?.(event) || ctx.languageCode;
         const configuration = this.getBestConfiguration(ctx.channel.code, languageCode);
-        const subject = configuration ? configuration.subject : this.defaultSubject;
+        let subject: string | undefined;
+        if (configuration) {
+            subject = configuration.subject;
+        } else if (typeof this.subject === 'function') {
+            subject = await this.subject(event, ctx, injector);
+        } else {
+            subject = this.subject;
+        }
         if (subject == null) {
             throw new Error(
                 `No subject field has been defined. ` +

--- a/packages/email-plugin/src/plugin.spec.ts
+++ b/packages/email-plugin/src/plugin.spec.ts
@@ -666,6 +666,37 @@ describe('EmailPlugin', () => {
         });
     });
 
+    describe('dynamic subject', () => {
+        it('supports function-based subjects and passes dependencies', async () => {
+            let eventArg: MockEvent | undefined;
+            let ctxArg: RequestContext | undefined;
+            let injectorArg: Injector | undefined;
+            const handler = new EmailEventListener('test')
+                .on(MockEvent)
+                .setFrom('"test from" <noreply@test.com>')
+                .setRecipient(() => 'test@test.com')
+                .setSubject((event, ctx, injector) => {
+                    eventArg = event;
+                    ctxArg = ctx;
+                    injectorArg = injector;
+                    return 'dynamic ' + (event.shouldSend ? 'yes' : 'no');
+                });
+
+            await initPluginWithHandlers([handler]);
+            const ctx = RequestContext.deserialize({
+                _channel: { code: DEFAULT_CHANNEL_CODE },
+                _languageCode: LanguageCode.en,
+            } as any);
+            eventBus.publish(new MockEvent(ctx, true));
+            await pause();
+
+            expect(onSend.mock.calls[0][0].subject).toBe('dynamic yes');
+            expect(eventArg).toBeInstanceOf(MockEvent);
+            expect(ctxArg).toBe(ctx);
+            expect(injectorArg?.constructor.name).toBe('Injector');
+        });
+    });
+
     describe('orderConfirmationHandler', () => {
         beforeEach(async () => {
             await initPluginWithHandlers([orderConfirmationHandler], {

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -378,6 +378,19 @@ export type SetTemplateVarsFn<Event> = (
 
 /**
  * @description
+ * A function used to generate the subject of the email.
+ *
+ * @docsCategory core plugins/EmailPlugin
+ * @docsPage Email Plugin Types
+ */
+export type SetSubjectFn<Event> = (
+    event: Event,
+    ctx: RequestContext,
+    injector: Injector,
+) => string | Promise<string>;
+
+/**
+ * @description
  * A function used to define attachments to be sent with the email.
  * See https://nodemailer.com/message/attachments/ for more information about
  * how attachments work in Nodemailer.


### PR DESCRIPTION
## Summary
- allow `setSubject()` to accept a function
- document new `SetSubjectFn` type
- test dynamic subject functions

## Testing
- `npx lerna run test --stream --no-bail --scope @vendure/email-plugin` *(fails: EHOSTUNREACH)*